### PR TITLE
Shared instance ports preparation

### DIFF
--- a/jobs/cf-redis-broker/spec
+++ b/jobs/cf-redis-broker/spec
@@ -141,6 +141,12 @@ properties:
   redis.broker.start_redis_timeout:
     description: Maximum wait time in seconds for Redis to start up
     default: 600
+  redis.broker.shared_max_port:
+    description: The preferred upper port range to allocate for shared instances (e.g. "40000"). If no free port is available within the preferred range, the service instance creation request will fail. 
+    default: 65535    
+  redis.broker.shared_min_port:
+    description: The preferred lower port range to allocate for shared instances (e.g. "30000"). If no free port is available within this range, the service instance creation request will fail.
+    default: 1024
   redis.broker.service_instance_limit:
     description: The maximum number of instances allowed
   redis.broker.auth.username:

--- a/jobs/cf-redis-broker/templates/broker.yml.erb
+++ b/jobs/cf-redis-broker/templates/broker.yml.erb
@@ -29,6 +29,8 @@ redis:
   process_check_interval: <%= p('redis.broker.process_check_interval') %>
   start_redis_timeout: <%= p('redis.broker.start_redis_timeout') %>
   service_instance_limit: <%= p('redis.broker.service_instance_limit') %>
+  shared_min_port:  <%= p('redis.broker.shared_min_port') %>
+  shared_max_port:  <%= p('redis.broker.shared_max_port') %>
   provider_display_name: <%= p('redis.broker.provider_display_name') %>
   documentation_url: <%= p('redis.broker.documentation_url') %>
   support_url: <%= p('redis.broker.support_url') %>

--- a/templates/sample_stubs/meta-openstack.yml
+++ b/templates/sample_stubs/meta-openstack.yml
@@ -35,6 +35,8 @@ meta:
       service_id: 7aba7e52-f61b-4263-9de1-14e9d11fb67d
       shared_vm_plan_id: 78bf886c-bc50-4f31-a03c-cb786a158286
       dedicated_vm_plan_id: 48b35349-d3de-4e19-bc4a-66996ae07766
+      shared_max_port: 40005
+      shared_min_port: 40000
     dedicated_plan:
       instance_count: 3
     shared_plan:


### PR DESCRIPTION
As documented in https://github.com/pivotal-cf/cf-redis-release/issues/36, this PR adds control to the choice of the port in the precise range.

---- 
Details over the end-to-end tests performed:

Scenario: **shared instance uses a port in the preferred range**
* given a redis deployment with 
   * redis.broker.shared_min_port=40000 redis.broker.shared_max_port=40000
* when
   * cf bind-service redis-instance app
* then
   * returned port within VCAP_SERVICES is 40000

Scenario: **shared instances rejects service binding when not available port in the preferred range, providing clear error message to service operators and possibly end-users**
* given a redis deployment with 
   * redis.broker.shared_min_port=40000 redis.broker.shared_max_port=40000
* when
   * cf bind-service redis-instance1 app
   * cf bind-service redis-instance2 app
* then
   * ``cf bind-service redis-instance2 app`` fails with error message 
   * redis operator logs contains log entry:

Scenario: **operator misconfigurations of preferred port range, fail deployment with clear error message.**
* given a redis deployment descriptor with 
   * redis.broker.shared_min_port=40000 redis.broker.shared_max_port=30000
* when
   * the bosh deploy is requested
* Then
   * the redis-dedicated-job fails to start
   * and the redis-dedicated-job log entry indicates ""
